### PR TITLE
Fix maps list - remove Spring/Summer, add Gorge/Swamp/Other

### DIFF
--- a/lib/constants/maps.ts
+++ b/lib/constants/maps.ts
@@ -12,9 +12,12 @@ export const MAPS = [
   "Lake",
   "Mountain",
 
+  // Homeland Expansion (upcoming)
+  "Gorge",
+  "Swamp",
+
   // Custom/Community
-  "Spring",
-  "Summer",
+  "Other",
 ] as const;
 
 export type Map = typeof MAPS[number];
@@ -29,16 +32,18 @@ export const MAP_ALIASES: Record<string, Map> = {
   "winter": "Winter",
   "lake": "Lake",
   "mountain": "Mountain",
-  "spring": "Spring",
-  "summer": "Summer",
+  "gorge": "Gorge",
+  "swamp": "Swamp",
+  "other": "Other",
+  "custom": "Other",
 
   // French translations
   "automne": "Fall",
   "hiver": "Winter",
   "lac": "Lake",
   "montagne": "Mountain",
-  "printemps": "Spring",
-  "été": "Summer",
+  "marais": "Swamp",
+  "autre": "Other",
 };
 
 /**
@@ -49,6 +54,7 @@ export const MAP_DESCRIPTIONS: Record<Map, string> = {
   "Winter": "Base game map - frozen river variation",
   "Lake": "Underworld expansion - lake centerpiece",
   "Mountain": "Underworld expansion - mountain terrain",
-  "Spring": "Community map - spring theme",
-  "Summer": "Community map - summer theme",
+  "Gorge": "Homeland expansion - gorge terrain",
+  "Swamp": "Homeland expansion - swamp terrain",
+  "Other": "Custom or community map",
 };

--- a/lib/ocr/vision-prompt.ts
+++ b/lib/ocr/vision-prompt.ts
@@ -11,6 +11,9 @@ import { MAPS } from "@/lib/constants/maps";
  */
 export function generateVisionPrompt(): string {
   const factionList = FACTIONS.map((f, i) => `${i + 1}. "${f}"`).join("\n");
+
+  // Only include maps available in the digital game (OCR is for digital screenshots only)
+  // Physical maps (Gorge, Swamp) and custom maps are for manual entry
   const mapList = MAPS.filter(m => ["Fall", "Winter", "Lake", "Mountain"].includes(m))
     .map((m, i) => `${i + 1}. "${m}"`).join("\n");
 


### PR DESCRIPTION
## Changes
- ❌ Removed non-existent **Spring** and **Summer** maps
- ✅ Added upcoming **Homeland expansion** maps: **Gorge** and **Swamp**
- ✅ Added **"Other"** option for custom/community maps
- 📝 Updated map descriptions and aliases
- 💡 Added clarifying comment in OCR vision prompt about digital-only maps

## Notes
- OCR vision prompt continues to only recognize Fall/Winter/Lake/Mountain (digital game maps)
- Gorge/Swamp/Other are available for manual entry of physical board games
- Build passes ✓

Fixes #1