### PR TITLE
Add Vagabond coalition support for dominance victories

### DIFF
--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -67,6 +67,7 @@ export async function POST(req: NextRequest) {
         score: p.score,
         isWinner: p.isWinner,
         isDominance: p.isDominance,
+        coalitionWith: p.coalitionWith,
         order: p.order,
       }))
     );

--- a/components/games/GameForm.tsx
+++ b/components/games/GameForm.tsx
@@ -18,6 +18,7 @@ interface Player {
   score?: number;
   isWinner: boolean;
   isDominance: boolean;
+  coalitionWith?: string;
   order: number;
 }
 
@@ -38,6 +39,7 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
       score: undefined,
       isWinner: false,
       isDominance: false,
+      coalitionWith: undefined,
       order: 0,
     },
     {
@@ -46,6 +48,7 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
       score: undefined,
       isWinner: false,
       isDominance: false,
+      coalitionWith: undefined,
       order: 1,
     },
   ]);
@@ -61,6 +64,7 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
         score: undefined,
         isWinner: false,
         isDominance: false,
+        coalitionWith: undefined,
         order: players.length,
       },
     ]);
@@ -88,6 +92,7 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
       score?: number;
       isWinner?: boolean;
       isDominance?: boolean;
+      coalitionWith?: string;
       order?: number;
     }>;
   }) => {
@@ -105,6 +110,7 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
         score: ocrPlayer.score,
         isWinner: ocrPlayer.isWinner ?? false,
         isDominance: ocrPlayer.isDominance ?? false,
+        coalitionWith: ocrPlayer.coalitionWith,
         order: index,
       }));
 
@@ -363,6 +369,31 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
                   </div>
                 </div>
               </div>
+
+              {player.faction.startsWith("Vagabond") && player.isDominance && (
+                <div className="space-y-2 pt-3 border-t">
+                  <Label htmlFor={`player-${index}-coalition`}>
+                    Coalition Partner (Vagabond allies with this faction)
+                  </Label>
+                  <select
+                    id={`player-${index}-coalition`}
+                    value={player.coalitionWith || ""}
+                    onChange={(e) => updatePlayer(index, "coalitionWith", e.target.value || undefined)}
+                    disabled={isLoading}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <option value="">Select coalition partner</option>
+                    {FACTIONS.filter(f => !f.startsWith("Vagabond")).map((f) => (
+                      <option key={f} value={f}>
+                        {f}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground">
+                    The Vagabond wins if this faction wins
+                  </p>
+                </div>
+              )}
             </div>
           ))}
         </CardContent>

--- a/drizzle/0001_add_coalition_with.sql
+++ b/drizzle/0001_add_coalition_with.sql
@@ -1,0 +1,5 @@
+-- Rename is_dominance_victory to is_dominance for consistency
+ALTER TABLE "root_game_players" RENAME COLUMN "is_dominance_victory" TO "is_dominance";
+
+-- Add coalition_with column for Vagabond coalitions
+ALTER TABLE "root_game_players" ADD COLUMN "coalition_with" text;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -74,6 +74,7 @@ export const gamePlayers = pgTable("root_game_players", {
   score: integer("score"),
   isWinner: boolean("is_winner").default(false).notNull(),
   isDominance: boolean("is_dominance").default(false).notNull(),
+  coalitionWith: text("coalition_with"),
   order: integer("order").notNull(),
 });
 

--- a/lib/ocr/__tests__/vision-validation.test.ts
+++ b/lib/ocr/__tests__/vision-validation.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest';
+import { validateVisionResponse } from '../vision-prompt';
+
+describe('validateVisionResponse - Coalition Support', () => {
+  describe('Valid Coalition Scenarios', () => {
+    it('should accept Vagabond with dominance and coalition partner', () => {
+      const response = {
+        map: "Fall" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Marquise de Cat",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: null,
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Vagabond - Harrier",
+            score: null,
+            isWinner: true,
+            isDominance: true,
+            coalitionWith: "Marquise de Cat",
+            order: 1,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should accept Vagabond with dominance but no coalition (loses)', () => {
+      const response = {
+        map: "Winter" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Eyrie",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: null,
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Vagabond - Adventurer",
+            score: null,
+            isWinner: false,
+            isDominance: true,
+            coalitionWith: "Underground Duchy",
+            order: 1,
+          },
+          {
+            playerName: "Charlie",
+            faction: "Underground Duchy",
+            score: 20,
+            isWinner: false,
+            isDominance: false,
+            coalitionWith: null,
+            order: 2,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('Invalid Coalition Scenarios', () => {
+    it('should reject non-Vagabond with coalitionWith set', () => {
+      const response = {
+        map: "Fall" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Marquise de Cat",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: "Eyrie",
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Eyrie",
+            score: 25,
+            isWinner: false,
+            isDominance: false,
+            coalitionWith: null,
+            order: 1,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        "Player 0: coalitionWith can only be set for Vagabond factions"
+      );
+    });
+
+    it('should reject Vagabond with coalition but no dominance', () => {
+      const response = {
+        map: "Fall" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Marquise de Cat",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: null,
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Vagabond - Thief",
+            score: 20,
+            isWinner: false,
+            isDominance: false,
+            coalitionWith: "Eyrie",
+            order: 1,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        "Player 1: coalitionWith can only be set when isDominance is true"
+      );
+    });
+
+    it('should reject invalid faction name in coalitionWith', () => {
+      const response = {
+        map: "Fall" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Marquise de Cat",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: null,
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Vagabond - Ranger",
+            score: null,
+            isWinner: true,
+            isDominance: true,
+            coalitionWith: "Invalid Faction",
+            order: 1,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes("coalitionWith must be a valid faction name"))).toBe(true);
+    });
+  });
+
+  describe('Two Winners with Coalition', () => {
+    it('should accept two winners when one is Vagabond with dominance', () => {
+      const response = {
+        map: "Mountain" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Underground Duchy",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: null,
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Vagabond - Scoundrel",
+            score: null,
+            isWinner: true,
+            isDominance: true,
+            coalitionWith: "Underground Duchy",
+            order: 1,
+          },
+          {
+            playerName: "Charlie",
+            faction: "Corvid Conspiracy",
+            score: 20,
+            isWinner: false,
+            isDominance: false,
+            coalitionWith: null,
+            order: 2,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject two winners when neither is Vagabond with dominance', () => {
+      const response = {
+        map: "Fall" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Marquise de Cat",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: null,
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Eyrie",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            coalitionWith: null,
+            order: 1,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        "Two winners only allowed when one is a Vagabond with dominance"
+      );
+    });
+  });
+
+  describe('Normal Game (No Coalition)', () => {
+    it('should accept normal game without any coalitions', () => {
+      const response = {
+        map: "Lake" as const,
+        players: [
+          {
+            playerName: "Alice",
+            faction: "Eyrie",
+            score: 30,
+            isWinner: true,
+            isDominance: false,
+            order: 0,
+          },
+          {
+            playerName: "Bob",
+            faction: "Woodland Alliance",
+            score: 25,
+            isWinner: false,
+            isDominance: false,
+            order: 1,
+          },
+          {
+            playerName: "Charlie",
+            faction: "Marquise de Cat",
+            score: 20,
+            isWinner: false,
+            isDominance: false,
+            order: 2,
+          },
+        ],
+      };
+
+      const result = validateVisionResponse(response);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});

--- a/lib/ocr/vision-prompt.ts
+++ b/lib/ocr/vision-prompt.ts
@@ -179,7 +179,40 @@ Whether this player went for a dominance victory (regardless of whether they won
 - When isDominance is true, score should be null
 - A Vagabond with dominance can win alongside the main winner
 
-### 2f. order (number, required)
+### 2f. coalitionWith (string, optional)
+**ONLY FOR VAGABONDS WITH DOMINANCE**: The faction this Vagabond is allied with.
+
+**CRITICAL RULE:**
+- This field should ONLY be set when:
+  1. The player's faction is a Vagabond (any Vagabond type)
+  2. AND isDominance is true
+- For all other players, this field should be omitted or null
+
+**How to Detect Coalition:**
+When a Vagabond plays dominance, they form a coalition with another faction. Look for a **small faction icon** next to the Vagabond's avatar or in the Vagabond's player section.
+
+**Coalition Icon Identification Guide:**
+- **Orange banner icon** → coalitionWith: "Marquise de Cat"
+- **Blue banner icon** → coalitionWith: "Eyrie"
+- **Green banner icon** → coalitionWith: "Woodland Alliance"
+- **Yellow banner icon** → coalitionWith: "Lizard Cult"
+- **Cyan/Teal banner icon** → coalitionWith: "Riverfolk Company"
+- **Brown/Tan banner icon** → coalitionWith: "Underground Duchy"
+- **Black banner icon** → coalitionWith: "Corvid Conspiracy"
+- **Red banner icon** → coalitionWith: "Lord of the Hundreds"
+- **Dark gray/steel banner icon** → coalitionWith: "Keepers in Iron"
+- **Emerald green banner icon** → coalitionWith: "Knaves of Deepwood"
+- **Light green/aqua banner icon** → coalitionWith: "Lilypad Diaspora"
+- **Purple/indigo banner icon** → coalitionWith: "Twilight Council"
+
+**Important:**
+- The coalition icon will be a small colored banner/symbol showing which faction the Vagabond is allied with
+- Match the faction name EXACTLY from the valid faction list above
+- If you cannot detect a coalition icon for a Vagabond with dominance, omit this field or set to null
+- Only Vagabonds can have coalitions (when they play dominance)
+- When a Vagabond has a coalition, they win if their coalition partner wins
+
+### 2g. order (number, required)
 The position of this player in the scorebar (left to right).
 
 **Valid Range:** 0-5
@@ -211,6 +244,7 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
       "score": 30,
       "isWinner": true,
       "isDominance": false,
+      "coalitionWith": null,
       "order": 0
     },
     {
@@ -219,6 +253,7 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
       "score": null,
       "isWinner": false,
       "isDominance": true,
+      "coalitionWith": null,
       "order": 1
     }
   ]
@@ -302,7 +337,7 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
   ]
 }
 
-# EXAMPLE OUTPUT 3 (Two Winners: Faction + Vagabond with Dominance)
+# EXAMPLE OUTPUT 3 (Two Winners: Faction + Vagabond with Dominance Coalition)
 {
   "map": "Winter",
   "players": [
@@ -312,6 +347,7 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
       "score": 30,
       "isWinner": true,
       "isDominance": false,
+      "coalitionWith": null,
       "order": 0
     },
     {
@@ -320,6 +356,7 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
       "score": 25,
       "isWinner": false,
       "isDominance": false,
+      "coalitionWith": null,
       "order": 1
     },
     {
@@ -328,6 +365,7 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
       "score": null,
       "isWinner": true,
       "isDominance": true,
+      "coalitionWith": "Marquise de Cat",
       "order": 2
     },
     {
@@ -336,6 +374,7 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
       "score": 18,
       "isWinner": false,
       "isDominance": false,
+      "coalitionWith": null,
       "order": 3
     }
   ]
@@ -352,7 +391,9 @@ Return ONLY valid JSON with this exact structure (no markdown, no explanation, j
 - For Badgers: Arbiter Vagabond = single badger in armor, Keepers in Iron = faction with multiple armored badgers
 - The Scoundrel is the only Vagabond wearing a pumpkin mask (easy identifier!)
 - If a player has a dominance icon instead of a score: set score: null and isDominance: true
+- **COALITION DETECTION**: If a Vagabond has isDominance: true, look for a small faction icon showing their coalition partner
 - A Vagabond with dominance can win alongside another faction (2 winners maximum)
+- coalitionWith should ONLY be set for Vagabonds with isDominance: true
 - Scores are typically 0-40, but can go up to 100
 - When in doubt between factions, prioritize banner color over character appearance
 
@@ -370,6 +411,7 @@ export interface VisionOCRResponse {
     score: number | null;
     isWinner: boolean;
     isDominance: boolean;
+    coalitionWith?: string | null;
     order: number;
   }>;
 }
@@ -437,6 +479,18 @@ export function validateVisionResponse(response: unknown): {
     // Validate isDominance consistency
     if (player.isDominance && player.score !== null) {
       errors.push(`${prefix}: if isDominance is true, score must be null`);
+    }
+
+    // Validate coalitionWith
+    if (player.coalitionWith !== undefined && player.coalitionWith !== null) {
+      // coalitionWith should only be set for Vagabonds with dominance
+      if (!player.faction.startsWith("Vagabond")) {
+        errors.push(`${prefix}: coalitionWith can only be set for Vagabond factions`);
+      } else if (!player.isDominance) {
+        errors.push(`${prefix}: coalitionWith can only be set when isDominance is true`);
+      } else if (!FACTIONS.includes(player.coalitionWith as any)) {
+        errors.push(`${prefix}: coalitionWith must be a valid faction name, got "${player.coalitionWith}"`);
+      }
     }
 
     // Validate isWinner

--- a/lib/validations/game.ts
+++ b/lib/validations/game.ts
@@ -11,6 +11,7 @@ export const gamePlayerSchema = z.object({
   score: z.number().int().min(0).max(100).optional(),
   isWinner: z.boolean(),
   isDominance: z.boolean(),
+  coalitionWith: z.string().optional(),
   order: z.number().int().min(0),
 });
 
@@ -48,6 +49,45 @@ export const createGameSchema = z
     },
     {
       message: "Duplicate factions are not allowed (except Vagabond)",
+      path: ["players"],
+    }
+  )
+  .refine(
+    (data) => {
+      // Validate Vagabond coalitions
+      for (const player of data.players) {
+        // If coalitionWith is set, player must be a Vagabond with dominance
+        if (player.coalitionWith) {
+          if (!player.faction.includes("Vagabond")) {
+            return false;
+          }
+          if (!player.isDominance) {
+            return false;
+          }
+        }
+
+        // If Vagabond with dominance and marked as winner, must have coalitionWith
+        // OR there must be another non-Vagabond winner (the coalition partner)
+        if (
+          player.faction.includes("Vagabond") &&
+          player.isDominance &&
+          player.isWinner
+        ) {
+          const hasCoalitionSet = !!player.coalitionWith;
+          const hasOtherWinner = data.players.some(
+            (p) => p.isWinner && p !== player && !p.faction.includes("Vagabond")
+          );
+
+          if (!hasCoalitionSet && !hasOtherWinner) {
+            return false;
+          }
+        }
+      }
+      return true;
+    },
+    {
+      message:
+        "Coalition rules violated: Vagabonds with dominance must have a coalition partner set or a non-Vagabond winner",
       path: ["players"],
     }
   );


### PR DESCRIPTION
Implements tracking of which faction a Vagabond is allied with when they play dominance, per GitHub issue #6 part 2.

Database changes:
- Add coalitionWith field to game_players table
- Create migration to add column and rename is_dominance_victory

OCR updates:
- Update vision prompt to detect coalition icons
- Add validation for coalition partner faction names
- Add examples showing Vagabond coalition wins

UI changes:
- Add coalition partner selector for Vagabonds with dominance
- Show helpful text explaining coalition mechanics
- Update form to handle coalition data from OCR

Validation:
- Validate coalitionWith only set for Vagabonds with dominance
- Validate coalition partner is a valid faction
- Add comprehensive test coverage for coalition scenarios

All unit tests passing. TypeScript compilation successful.

🤖 Generated with Claude Code