### PR TITLE
Fix Lake map description - remove incorrect water references

### DIFF
--- a/docs/OCR_SPECIFICATION.md
+++ b/docs/OCR_SPECIFICATION.md
@@ -16,17 +16,18 @@ Root displays game results on a single screen with:
 **Location**: Background artwork
 **Type**: Visual identification (not text-based)
 **Digital Game Maps** (4 total):
-- **Fall** - Autumn forest with orange/red leaves (Base Game)
-- **Winter** - Snowy landscape (Base Game)
-- **Lake** - Water-dominated landscape with lake centerpiece (Underworld Expansion)
-- **Mountain** - Rocky peaks and mountain terrain (Underworld Expansion)
+- **Fall** - Autumn forest with orange/red leaves, warm golden/amber tones (Base Game)
+- **Winter** - Snowy landscape with white/blue tones (Base Game)
+- **Lake** - Dense green coniferous forest, darker woodland scenery (Underworld Expansion) - NOTE: Despite the name, this map does NOT show visible water features
+- **Mountain** - Rocky peaks and mountain terrain with gray/brown stone (Underworld Expansion)
 
 **Note**: Spring and Summer are community maps for physical game only, will never appear in digital screenshots.
 
 **Extraction Strategy**:
 - Analyze background color palette
-- Identify seasonal markers (snow, autumn colors, water features, mountains)
+- Identify seasonal markers (snow, warm autumn colors, coniferous forest greens, rocky mountains)
 - Match against known map visual patterns
+- Note: Lake map shows forest, not water
 
 **Difficulty**: Medium - Maps have distinct visual signatures but require color/texture analysis
 

--- a/lib/constants/maps.ts
+++ b/lib/constants/maps.ts
@@ -45,10 +45,10 @@ export const MAP_ALIASES: Record<string, Map> = {
  * Map descriptions for UI
  */
 export const MAP_DESCRIPTIONS: Record<Map, string> = {
-  "Fall": "Base game map - balanced terrain",
-  "Winter": "Base game map - frozen river variation",
-  "Lake": "Underworld expansion - lake centerpiece",
-  "Mountain": "Underworld expansion - mountain terrain",
+  "Fall": "Base game map - autumn forest with warm colors",
+  "Winter": "Base game map - snowy landscape",
+  "Lake": "Underworld expansion - dense coniferous forest (no water features)",
+  "Mountain": "Underworld expansion - rocky mountain terrain",
   "Spring": "Community map - spring theme",
   "Summer": "Community map - summer theme",
 };

--- a/lib/ocr/vision-prompt.ts
+++ b/lib/ocr/vision-prompt.ts
@@ -22,7 +22,7 @@ Extract all game result data from this image and return it as valid JSON.
 # IMAGE LAYOUT GUIDE
 The score screen has these elements:
 1. **Top Banner** (decorative text): Shows "[Faction Name] Wins" - the winner announcement
-2. **Background**: Map artwork (forest/snow/water/mountain scenery)
+2. **Background**: Map artwork (autumn forest/snowy landscape/green forest/rocky mountains)
 3. **Bottom Scorebar**: Horizontal bar with 2-6 colored player sections
 4. **Each Player Section Contains**:
    - Character avatar (3D model) showing the faction
@@ -38,10 +38,10 @@ The background scenery indicates which map was played.
 ${mapList}
 
 **Visual Identification Guide:**
-- "Fall": Autumn forest with orange/red leaves, warm colors
-- "Winter": Snowy landscape with white/blue tones, frozen terrain
-- "Lake": Large body of water in center/bottom, blue water feature
-- "Mountain": Rocky peaks, mountainous terrain, gray/brown peaks
+- "Fall": Autumn forest with orange/red leaves, warm golden/amber colors, deciduous trees
+- "Winter": Snowy landscape with white/blue tones, frozen terrain, snow-covered ground
+- "Lake": Dense green forest with coniferous trees, darker greens, woodland scenery (NOTE: despite the name, this map does NOT have visible water features)
+- "Mountain": Rocky peaks, mountainous terrain, gray/brown stone peaks and cliffs
 
 **Instructions:**
 - Look at the background artwork behind all UI elements


### PR DESCRIPTION
The Lake map was incorrectly described as having water features. Updated OCR prompts and documentation to correctly identify it as a dense green coniferous forest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)