### PR TITLE
Add optional description field to games

### DIFF
--- a/app/(dashboard)/leagues/[id]/page.tsx
+++ b/app/(dashboard)/leagues/[id]/page.tsx
@@ -126,6 +126,11 @@ export default async function LeagueDetailPage({ params }: { params: Promise<{ i
                           Winner: {winner?.playerName} ({winner?.faction})
                           {winner?.isDominance && " - Dominance"}
                         </p>
+                        {game.description && (
+                          <p className="text-sm text-muted-foreground italic">
+                            {game.description}
+                          </p>
+                        )}
                         <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
                           {game.players.map((p, i) => (
                             <span key={i}>

--- a/components/games/GameForm.tsx
+++ b/components/games/GameForm.tsx
@@ -31,6 +31,7 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
   const router = useRouter();
   const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
   const [map, setMap] = useState("");
+  const [description, setDescription] = useState("");
   const [players, setPlayers] = useState<Player[]>([
     {
       playerName: "",
@@ -169,6 +170,7 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
           leagueId,
           date,
           map,
+          description: description || undefined,
           players: players.map((p, i) => ({
             ...p,
             order: i,
@@ -234,6 +236,21 @@ export function GameForm({ leagueId, currentUsername, currentUserId }: GameFormP
                 ))}
               </select>
             </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="description">Description (Optional)</Label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={isLoading}
+              placeholder="Add details about hirelings, landmarks, turn order, or memorable moments..."
+              rows={3}
+              className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+            <p className="text-xs text-muted-foreground">
+              Include additional details like hirelings, landmarks, turn order, or memorable moments from the game
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/drizzle/0001_add_game_description.sql
+++ b/drizzle/0001_add_game_description.sql
@@ -1,0 +1,2 @@
+-- Add optional description field to games table
+ALTER TABLE "root_games" ADD COLUMN "description" text;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -53,6 +53,7 @@ export const games = pgTable("root_games", {
   leagueId: uuid("league_id").references(() => leagues.id, { onDelete: "cascade" }).notNull(),
   date: date("date").defaultNow().notNull(),
   map: text("map").notNull(),
+  description: text("description"),
   imageUrl: text("image_url"),
   entryMethod: text("entry_method", { enum: ["manual", "ocr_tesseract"] }).default("manual").notNull(),
   ocrCorrected: boolean("ocr_corrected"),

--- a/lib/validations/game.ts
+++ b/lib/validations/game.ts
@@ -21,6 +21,7 @@ export const createGameSchema = z
     map: z.enum(MAPS as unknown as [string, ...string[]], {
       message: "Invalid map",
     }),
+    description: z.string().optional(),
     players: z
       .array(gamePlayerSchema)
       .min(2, "At least 2 players required")


### PR DESCRIPTION
Added an optional description field to games that allows players to add additional details about their games. Includes helpful placeholder text suggesting details like hirelings, landmarks, turn order, or memorable moments.

Changes:
- Added description column to games table schema
- Updated validation schema to accept optional description
- Added textarea input to GameForm with helper text
- Display description in game cards on league page
- Created database migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)